### PR TITLE
feat(engine): add layer-based scenario selection (evaluation.scenarios_per_layer)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,6 +147,48 @@ Badge:
   none   < 60
 ```
 
+### Layer-Based Scenario Selection
+
+Suites can define an optional `evaluation.scenarios_per_layer` config to control how many scenarios are randomly selected per layer. This is useful when a suite has multiple scenarios per layer and you want to keep evaluations concise.
+
+**Rules:**
+- If `evaluation` is omitted → ALL scenarios run (backwards compatible)
+- If a layer is omitted from `scenarios_per_layer` → all scenarios for that layer are included
+- If a layer has a count → that many are randomly picked from that layer
+- Selection order follows the YAML definition order (not hardcoded)
+- Use `seed` parameter for deterministic/reproducible picks
+
+```typescript
+import { pickScenariosByLayer } from '@mondaycom/sensei-engine';
+
+// Pick scenarios respecting suite's evaluation config
+const selected = pickScenariosByLayer(suite);
+
+// Deterministic selection with seed
+const selected = pickScenariosByLayer(suite, 42);
+```
+
+**Example YAML configs:**
+
+```yaml
+# Pick 1 from each layer (concise evaluation)
+evaluation:
+  scenarios_per_layer:
+    execution: 1
+    reasoning: 1
+    self-improvement: 1
+
+# Pick 2 execution, 1 reasoning, all self-improvement
+evaluation:
+  scenarios_per_layer:
+    execution: 2
+    reasoning: 1
+    # self-improvement omitted → all included
+
+# No evaluation config → all scenarios run
+# (just don't include the evaluation key)
+```
+
 ### 2. LLM Judge (`judge.ts`)
 
 For KPIs that can't be measured automatically (e.g., "Is this email personalized?"), we use an LLM as judge.
@@ -319,6 +361,17 @@ judge:
 defaults:
   timeout_ms: 60000
   judge_model: gpt-4o
+
+# Layer-based scenario selection (optional)
+# Controls how many scenarios are randomly picked per evaluation layer.
+# Omit entirely → all scenarios run.
+# Omit a layer → all scenarios for that layer are included.
+# Order follows YAML definition order.
+evaluation:
+  scenarios_per_layer:
+    execution: 1          # pick 1 random from execution scenarios
+    reasoning: 1          # pick 1 random from reasoning scenarios
+    # self-improvement: omitted → all self-improvement scenarios included
 
 scenarios:
   - id: cold-email

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,12 +2,12 @@
 export * from './types.js';
 
 // Engine modules (Agent A)
-export { SuiteLoader, resolvePools } from './loader.js';
+export { SuiteLoader, resolvePools, pickScenariosByLayer } from './loader.js';
 export { Runner } from './runner.js';
 export type { RunnerOptions } from './runner.js';
 export { Scorer } from './scorer.js';
 export { Reporter } from './reporter.js';
-export { SuiteDefinitionSchema, SuiteDefinitionSchema as suiteSchema, ScenarioPoolSchema, ScenarioEntrySchema, MarketplaceSchema } from './schema.js';
+export { SuiteDefinitionSchema, SuiteDefinitionSchema as suiteSchema, ScenarioPoolSchema, ScenarioEntrySchema, MarketplaceSchema, EvaluationConfigSchema } from './schema.js';
 
 // Registry client
 export { RegistryClient, DEFAULT_REGISTRY_URL } from './registry-client.js';

--- a/packages/engine/src/loader.ts
+++ b/packages/engine/src/loader.ts
@@ -14,7 +14,7 @@ import { parse as parseYAML, YAMLParseError } from 'yaml';
 import { ZodError } from 'zod';
 import { SuiteDefinitionSchema } from './schema.js';
 import { RegistryClient } from './registry-client.js';
-import type { SuiteDefinition, ScenarioDefinition, ScenarioEntry, ScenarioPool } from './types.js';
+import type { SuiteDefinition, ScenarioDefinition, ScenarioEntry, ScenarioPool, EvaluationLayer } from './types.js';
 
 export class SuiteLoader {
   /**
@@ -238,4 +238,64 @@ export function resolvePools(suite: { scenarios: ScenarioEntry[] }): void {
   }
 
   (suite as any).scenarios = resolved;
+}
+
+// ─── Layer-Based Scenario Selection ─────────────────────────────────
+
+/**
+ * Pick scenarios from a suite respecting the `evaluation.scenarios_per_layer` config.
+ *
+ * Behavior:
+ * - If `evaluation.scenarios_per_layer` is not defined, ALL scenarios are returned.
+ * - If a layer is omitted from the map, ALL scenarios for that layer are included.
+ * - If a layer has a count, that many are randomly picked from that layer's scenarios.
+ * - Order follows the original YAML definition order.
+ *
+ * @param suite  A suite definition (pools should already be resolved)
+ * @param seed   Optional seed for deterministic random selection
+ * @returns      Selected scenarios in YAML definition order
+ */
+export function pickScenariosByLayer(
+  suite: SuiteDefinition,
+  seed?: number,
+): ScenarioDefinition[] {
+  const config = suite.evaluation?.scenarios_per_layer;
+
+  // No config → return all scenarios as-is
+  if (!config) {
+    return [...suite.scenarios];
+  }
+
+  // Group scenarios by layer, preserving original order via index
+  const byLayer = new Map<EvaluationLayer, { index: number; scenario: ScenarioDefinition }[]>();
+  for (let i = 0; i < suite.scenarios.length; i++) {
+    const s = suite.scenarios[i];
+    if (!byLayer.has(s.layer)) byLayer.set(s.layer, []);
+    byLayer.get(s.layer)!.push({ index: i, scenario: s });
+  }
+
+  const rand = seed != null ? mulberry32(seed) : Math.random.bind(Math);
+  const selected: { index: number; scenario: ScenarioDefinition }[] = [];
+
+  for (const [layer, entries] of byLayer) {
+    const limit = config[layer];
+
+    if (limit === undefined) {
+      // Layer not in config → include all
+      selected.push(...entries);
+    } else {
+      const count = Math.min(limit, entries.length);
+      if (limit > entries.length) {
+        console.warn(
+          `scenarios_per_layer.${layer}: requested ${limit} but only ${entries.length} available, using all`,
+        );
+      }
+      const shuffled = shuffle(entries, rand);
+      selected.push(...shuffled.slice(0, count));
+    }
+  }
+
+  // Sort by original YAML index to preserve definition order
+  selected.sort((a, b) => a.index - b.index);
+  return selected.map((e) => e.scenario);
 }

--- a/packages/engine/src/schema.ts
+++ b/packages/engine/src/schema.ts
@@ -96,6 +96,16 @@ export const JudgeConfigSchema = z.object({
   multi_judge: z.boolean().optional(),
 });
 
+// ─── Evaluation Config ───────────────────────────────────────────────
+
+export const EvaluationConfigSchema = z.object({
+  scenarios_per_layer: z.object({
+    execution: z.number().int().min(1).optional(),
+    reasoning: z.number().int().min(1).optional(),
+    'self-improvement': z.number().int().min(1).optional(),
+  }).optional(),
+}).optional();
+
 // ─── Suite Definition ────────────────────────────────────────────────
 
 // M13: Suite-level defaults that apply to all scenarios
@@ -119,6 +129,7 @@ export const SuiteDefinitionSchema = z.object({
   description: z.string().optional(),
   agent: AgentConfigSchema.optional(),
   judge: JudgeConfigSchema.optional(),
+  evaluation: EvaluationConfigSchema,
   defaults: SuiteDefaultsSchema,
   marketplace: MarketplaceSchema,
   scenarios: z.array(ScenarioEntrySchema).min(1),

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -11,6 +11,23 @@ export interface MarketplaceMetadata {
   tags?: string[];
 }
 
+/**
+ * Controls how many scenarios are picked per evaluation layer.
+ *
+ * Example:
+ *   scenarios_per_layer:
+ *     execution: 1        # pick 1 random from execution scenarios
+ *     reasoning: 1        # pick 1 random from reasoning scenarios
+ *     # self-improvement omitted → all self-improvement scenarios included
+ *
+ * If `scenarios_per_layer` is omitted entirely, ALL scenarios run.
+ * If a layer is omitted from the map, ALL scenarios for that layer are included.
+ * Order follows the YAML definition order.
+ */
+export interface EvaluationConfig {
+  scenarios_per_layer?: Partial<Record<EvaluationLayer, number>>;
+}
+
 export interface SuiteDefinition {
   id: string;
   name: string;
@@ -19,6 +36,7 @@ export interface SuiteDefinition {
   description?: string;
   agent?: AgentConfig;
   judge?: JudgeConfig;
+  evaluation?: EvaluationConfig;
   marketplace?: MarketplaceMetadata;
   scenarios: ScenarioDefinition[];
   metadata?: Record<string, unknown>;

--- a/packages/engine/tests/pick-scenarios-by-layer.test.ts
+++ b/packages/engine/tests/pick-scenarios-by-layer.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { pickScenariosByLayer } from '../src/loader.js';
+import type { SuiteDefinition, ScenarioDefinition, EvaluationLayer } from '../src/types.js';
+
+function makeScenario(id: string, layer: EvaluationLayer): ScenarioDefinition {
+  return {
+    id,
+    name: `Scenario ${id}`,
+    layer,
+    input: { prompt: `Prompt for ${id}` },
+    kpis: [{ id: 'k1', name: 'K1', weight: 1, method: 'llm-judge', config: { rubric: 'test' } }],
+  };
+}
+
+function makeSuite(
+  scenarios: ScenarioDefinition[],
+  evaluation?: SuiteDefinition['evaluation'],
+): SuiteDefinition {
+  return {
+    id: 'test-suite',
+    name: 'Test Suite',
+    version: '1.0',
+    evaluation,
+    scenarios,
+  };
+}
+
+describe('pickScenariosByLayer', () => {
+  const exec1 = makeScenario('exec-1', 'execution');
+  const exec2 = makeScenario('exec-2', 'execution');
+  const exec3 = makeScenario('exec-3', 'execution');
+  const reason1 = makeScenario('reason-1', 'reasoning');
+  const reason2 = makeScenario('reason-2', 'reasoning');
+  const selfImp1 = makeScenario('self-1', 'self-improvement');
+
+  const allScenarios = [exec1, exec2, exec3, reason1, reason2, selfImp1];
+
+  it('returns all scenarios when no evaluation config', () => {
+    const suite = makeSuite(allScenarios);
+    const result = pickScenariosByLayer(suite);
+    expect(result).toHaveLength(6);
+    expect(result.map((s) => s.id)).toEqual(['exec-1', 'exec-2', 'exec-3', 'reason-1', 'reason-2', 'self-1']);
+  });
+
+  it('returns all scenarios when evaluation config has no scenarios_per_layer', () => {
+    const suite = makeSuite(allScenarios, {});
+    const result = pickScenariosByLayer(suite);
+    expect(result).toHaveLength(6);
+  });
+
+  it('picks specified count per layer, includes all for undefined layers', () => {
+    const suite = makeSuite(allScenarios, {
+      scenarios_per_layer: {
+        execution: 1,
+        // reasoning: omitted → all 2
+        // self-improvement: omitted → all 1
+      },
+    });
+    const result = pickScenariosByLayer(suite, 42);
+    // 1 execution + 2 reasoning + 1 self-improvement = 4
+    expect(result).toHaveLength(4);
+
+    const execPicked = result.filter((s) => s.layer === 'execution');
+    const reasonPicked = result.filter((s) => s.layer === 'reasoning');
+    const selfPicked = result.filter((s) => s.layer === 'self-improvement');
+    expect(execPicked).toHaveLength(1);
+    expect(reasonPicked).toHaveLength(2);
+    expect(selfPicked).toHaveLength(1);
+  });
+
+  it('picks 1 from each layer when all specified as 1', () => {
+    const suite = makeSuite(allScenarios, {
+      scenarios_per_layer: {
+        execution: 1,
+        reasoning: 1,
+        'self-improvement': 1,
+      },
+    });
+    const result = pickScenariosByLayer(suite, 42);
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.layer)).toEqual(['execution', 'reasoning', 'self-improvement']);
+  });
+
+  it('preserves YAML definition order', () => {
+    // Reverse order in YAML: self-improvement first, then reasoning, then execution
+    const reversed = [selfImp1, reason1, reason2, exec1, exec2, exec3];
+    const suite = makeSuite(reversed, {
+      scenarios_per_layer: {
+        execution: 1,
+        reasoning: 1,
+        'self-improvement': 1,
+      },
+    });
+    const result = pickScenariosByLayer(suite, 42);
+    expect(result).toHaveLength(3);
+    // Order should follow YAML: self-improvement → reasoning → execution
+    expect(result[0].layer).toBe('self-improvement');
+    expect(result[1].layer).toBe('reasoning');
+    expect(result[2].layer).toBe('execution');
+  });
+
+  it('clamps when count exceeds available scenarios', () => {
+    const suite = makeSuite(allScenarios, {
+      scenarios_per_layer: {
+        execution: 10, // only 3 available
+      },
+    });
+    const result = pickScenariosByLayer(suite, 42);
+    const execPicked = result.filter((s) => s.layer === 'execution');
+    expect(execPicked).toHaveLength(3); // clamped to available
+  });
+
+  it('is deterministic with same seed', () => {
+    const suite = makeSuite(allScenarios, {
+      scenarios_per_layer: { execution: 1, reasoning: 1 },
+    });
+    const r1 = pickScenariosByLayer(suite, 123);
+    const r2 = pickScenariosByLayer(suite, 123);
+    expect(r1.map((s) => s.id)).toEqual(r2.map((s) => s.id));
+  });
+
+  it('produces different results with different seeds', () => {
+    const suite = makeSuite(allScenarios, {
+      scenarios_per_layer: { execution: 1 },
+    });
+    // Run with many seeds to find at least one different pick
+    const picks = new Set<string>();
+    for (let seed = 0; seed < 20; seed++) {
+      const result = pickScenariosByLayer(suite, seed);
+      const execId = result.find((s) => s.layer === 'execution')!.id;
+      picks.add(execId);
+    }
+    expect(picks.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## What

Adds `evaluation.scenarios_per_layer` config to suite YAML schema, allowing suite authors to control how many scenarios are randomly selected per evaluation layer.

## Why

Previously, scenario selection was either "run all" or done externally by consumers (e.g. agentalent's blind `shuffle + slice`). This led to unbalanced evaluations — potentially 3 execution scenarios and 0 reasoning.

Suite authors should control the evaluation structure.

## How

### New YAML config
```yaml
evaluation:
  scenarios_per_layer:
    execution: 1        # pick 1 random from execution scenarios
    reasoning: 1        # pick 1 random from reasoning scenarios
    # self-improvement: omitted → all included
```

### Rules
- No `evaluation` config → ALL scenarios run (backwards compatible)
- Layer omitted from `scenarios_per_layer` → all scenarios for that layer included
- Layer with count → that many randomly picked (seeded PRNG for determinism)
- **Order follows YAML definition order** (not hardcoded)

### Changes
- `types.ts`: New `EvaluationConfig` interface on `SuiteDefinition`
- `schema.ts`: Zod validation for `evaluation.scenarios_per_layer`
- `loader.ts`: New `pickScenariosByLayer()` function (exported)
- `index.ts`: Export `pickScenariosByLayer` + `EvaluationConfigSchema`
- `ARCHITECTURE.md`: Docs section + YAML example
- 8 new tests covering all selection behaviors

### Test results
```
Test Files  16 passed (16)
     Tests  226 passed (226)
```

## Breaking changes
None. The `evaluation` field is optional with full backwards compatibility.